### PR TITLE
Add media attachments support

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,15 +7,13 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": []
+		"includes": ["**"]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab"
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/example/index.ts
+++ b/example/index.ts
@@ -10,19 +10,19 @@ const onlyMessageView = defineView().render(function () {
 			new InlineKeyboard()
 				.columns(1)
 				.text("Message with text only ›", "TEXT")
-				.text("Message with signle media ›", "MEDIA")
+				.text("Message with single media ›", "MEDIA")
 				.text("Message with media group ›", "MEDIA_GROUP"),
 		);
 });
 
-const signleMediaView = defineView().render(async function () {
+const singleMediaView = defineView().render(async function () {
 	return this.response
-		.text("Message with signle media.")
+		.text("Message with single media.")
 		.keyboard(
 			new InlineKeyboard()
 				.columns(1)
 				.text("Message with text only ›", "TEXT")
-				.text("Message with signle media ›", "MEDIA")
+				.text("Message with single media ›", "MEDIA")
 				.text("Message with media group ›", "MEDIA_GROUP"),
 		)
 		.media(
@@ -48,7 +48,7 @@ const bot = new Bot(process.env.BOT_TOKEN!)
 		return context.render(onlyMessageView);
 	})
 	.command("media", async (context) => {
-		return context.render(signleMediaView);
+		return context.render(singleMediaView);
 	})
 	.command("media_group", async (context) => {
 		return context.render(mediaGroupView);
@@ -58,7 +58,7 @@ const bot = new Bot(process.env.BOT_TOKEN!)
 			return context.render(onlyMessageView);
 		}
 		if (context.queryPayload === "MEDIA") {
-			return context.render(signleMediaView);
+			return context.render(singleMediaView);
 		}
 		if (context.queryPayload === "MEDIA_GROUP") {
 			return context.render(mediaGroupView);

--- a/example/index.ts
+++ b/example/index.ts
@@ -5,7 +5,7 @@ const defineView = initViewsBuilder();
 
 const onlyMessageView = defineView().render(function () {
 	return this.response
-		.text(`Only message. Current timestamp: ${Date.now()}`)
+		.text(`Only message. Current timestamp: ${new Date().toISOString()}`)
 		.keyboard(
 			new InlineKeyboard()
 				.columns(1)
@@ -35,7 +35,7 @@ const mediaGroupView = defineView().render(async function () {
 		.text("Message with media group. Buttons is not allowed.")
 		.media([
 			MediaInput.photo(await MediaUpload.url("https://picsum.photos/500")),
-			MediaInput.photo(await MediaUpload.url("https://picsum.photos/500")),
+			MediaInput.photo("https://picsum.photos/500"),
 			MediaInput.photo(await MediaUpload.url("https://picsum.photos/500")),
 		]);
 });
@@ -53,16 +53,15 @@ const bot = new Bot(process.env.BOT_TOKEN!)
 	.command("media_group", async (context) => {
 		return context.render(mediaGroupView);
 	})
-	.on("callback_query", async (context) => {
-		if (context.queryPayload === "TEXT") {
-			return context.render(onlyMessageView);
-		}
-		if (context.queryPayload === "MEDIA") {
-			return context.render(singleMediaView);
-		}
-		if (context.queryPayload === "MEDIA_GROUP") {
-			return context.render(mediaGroupView);
-		}
-	});
+	.callbackQuery("TEXT", async (context) => {
+		return context.render(onlyMessageView);
+	})
+	.callbackQuery("MEDIA", async (context) => {
+		return context.render(singleMediaView);
+	})
+	.callbackQuery("MEDIA_GROUP", async (context) => {
+		return context.render(mediaGroupView);
+	})
+	.onStart(console.log);
 
 bot.start();

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,0 +1,68 @@
+import { initViewsBuilder } from "@gramio/views";
+import { Bot, InlineKeyboard, MediaInput, MediaUpload } from "gramio";
+
+const defineView = initViewsBuilder();
+
+const onlyMessageView = defineView().render(function () {
+	return this.response
+		.text(`Only message. Current timestamp: ${Date.now()}`)
+		.keyboard(
+			new InlineKeyboard()
+				.columns(1)
+				.text("Message with text only ›", "TEXT")
+				.text("Message with signle media ›", "MEDIA")
+				.text("Message with media group ›", "MEDIA_GROUP"),
+		);
+});
+
+const signleMediaView = defineView().render(async function () {
+	return this.response
+		.text("Message with signle media.")
+		.keyboard(
+			new InlineKeyboard()
+				.columns(1)
+				.text("Message with text only ›", "TEXT")
+				.text("Message with signle media ›", "MEDIA")
+				.text("Message with media group ›", "MEDIA_GROUP"),
+		)
+		.media(
+			MediaInput.photo(await MediaUpload.url("https://picsum.photos/500")),
+		);
+});
+
+const mediaGroupView = defineView().render(async function () {
+	return this.response
+		.text("Message with media group. Buttons is not allowed.")
+		.media([
+			MediaInput.photo(await MediaUpload.url("https://picsum.photos/500")),
+			MediaInput.photo(await MediaUpload.url("https://picsum.photos/500")),
+			MediaInput.photo(await MediaUpload.url("https://picsum.photos/500")),
+		]);
+});
+
+const bot = new Bot(process.env.BOT_TOKEN!)
+	.derive(["message", "callback_query"], (context) => ({
+		render: defineView.buildRender(context, {}),
+	}))
+	.command("text", async (context) => {
+		return context.render(onlyMessageView);
+	})
+	.command("media", async (context) => {
+		return context.render(signleMediaView);
+	})
+	.command("media_group", async (context) => {
+		return context.render(mediaGroupView);
+	})
+	.on("callback_query", async (context) => {
+		if (context.queryPayload === "TEXT") {
+			return context.render(onlyMessageView);
+		}
+		if (context.queryPayload === "MEDIA") {
+			return context.render(signleMediaView);
+		}
+		if (context.queryPayload === "MEDIA_GROUP") {
+			return context.render(mediaGroupView);
+		}
+	});
+
+bot.start();

--- a/src/render.ts
+++ b/src/render.ts
@@ -21,77 +21,23 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 		const contextData = this.createContext(globals);
 		const result = this.render.apply(contextData, args);
 		const response = result[responseKey];
-		const { text, keyboard, media } = response;
+
+		const canEdit = context.is("callback_query") && !!context.message;
+		const strategy: "send" | "edit" =
+			strategyRaw === "send" ? "send" : canEdit ? "edit" : "send";
 
 		if (
-			context.is("message") ||
-			(context.is("callback_query") && !context.message)
+			strategy === "edit" &&
+			context.is("callback_query") &&
+			context.message
 		) {
-			if (Array.isArray(media) && media.length > 1) {
-				const lastMedia = media.at(-1);
-				if (lastMedia && text) {
-					lastMedia.caption = text;
-				}
-				await context.sendMediaGroup(media);
-			} else if (media) {
-				const signleMedia = Array.isArray(media) ? media[0] : media;
-				// @ts-expect-error
-				await context.sendMedia({
-					type: signleMedia.type,
-					[signleMedia.type]: signleMedia.media,
-					caption: text,
-					reply_markup: keyboard,
-				});
-			} else if (text) {
-				await context.send(text, { reply_markup: keyboard });
-			}
-
-			if (context.is("callback_query")) {
-				await context.answer();
-			}
-			return;
+			await this.performEdit(context, response);
+		} else {
+			await this.performSend(context, response);
 		}
 
-		if (context.is("callback_query") && context.message) {
-			if (Array.isArray(media)) {
-				await context.message.delete();
-				await context.sendMediaGroup(media);
-				return;
-			}
-
-			const hasCurrentMedia = context.message.hasAttachment();
-			const hasDesiredMedia = !!media;
-
-			if (hasCurrentMedia && !hasDesiredMedia && text) {
-				await context.message.delete();
-				await context.send(text, { reply_markup: keyboard });
-				return;
-			}
-
-			if (hasDesiredMedia) {
-				const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
-				await context.editMedia(
-					{
-						type: media.type,
-						media: media.media,
-						caption: text,
-					},
-					{ reply_markup: inlineMarkup },
-				);
-				return;
-			}
-
-			if (!hasCurrentMedia && text) {
-				const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
-				await context.editText(text, { reply_markup: inlineMarkup });
-				return;
-			}
-
-			if (keyboard && !text && !media) {
-				const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
-				await context.editReplyMarkup(inlineMarkup);
-				return;
-			}
+		if (context.is("callback_query")) {
+			await context.answer();
 		}
 	}
 
@@ -100,5 +46,82 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 			response: new ResponseView(),
 			...globals,
 		};
+	}
+
+	private async performSend(
+		context: ContextType<BotLike, "message" | "callback_query">,
+		response: ResponseView["response"],
+	) {
+		const { text, keyboard, media } = response;
+
+		if (Array.isArray(media) && media.length > 1) {
+			const lastMedia = media.at(-1);
+			if (lastMedia && text) {
+				lastMedia.caption = text;
+			}
+			await context.sendMediaGroup(media);
+		} else if (media) {
+			const signleMedia = Array.isArray(media) ? media[0] : media;
+			// @ts-expect-error
+			await context.sendMedia({
+				type: signleMedia.type,
+				[signleMedia.type]: signleMedia.media,
+				caption: text,
+				reply_markup: keyboard,
+			});
+		} else if (text) {
+			await context.send(text, { reply_markup: keyboard });
+		}
+	}
+
+	private async performEdit(
+		context: ContextType<BotLike, "callback_query">,
+		response: ResponseView["response"],
+	) {
+		const { text, keyboard, media } = response;
+
+		if (!context.hasMessage()) {
+			return;
+		}
+
+		if (Array.isArray(media)) {
+			await context.message.delete();
+			await context.sendMediaGroup(media);
+			return;
+		}
+
+		const hasCurrentMedia = context.message.hasAttachment();
+		const hasDesiredMedia = !!media;
+
+		if (hasCurrentMedia && !hasDesiredMedia && text) {
+			await context.message.delete();
+			await context.send(text, { reply_markup: keyboard });
+			return;
+		}
+
+		if (hasDesiredMedia) {
+			const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
+			await context.editMedia(
+				{
+					type: media.type,
+					media: media.media,
+					caption: text,
+				},
+				{ reply_markup: inlineMarkup },
+			);
+			return;
+		}
+
+		if (!hasCurrentMedia && text) {
+			const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
+			await context.editText(text, { reply_markup: inlineMarkup });
+			return;
+		}
+
+		if (keyboard && !text && !media) {
+			const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
+			await context.editReplyMarkup(inlineMarkup);
+			return;
+		}
 	}
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -89,8 +89,10 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 			if (lastMedia && text) {
 				lastMedia.caption = text;
 			}
-			await context.message.delete();
-			await context.sendMediaGroup(media);
+			await Promise.all([
+				context.message.delete(),
+				context.sendMediaGroup(media),
+			]);
 			return;
 		}
 
@@ -98,8 +100,10 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 		const hasDesiredMedia = !!media;
 
 		if (hasCurrentMedia && !hasDesiredMedia && text) {
-			await context.message.delete();
-			await context.send(text, { reply_markup: keyboard });
+			await Promise.all([
+				context.message.delete(),
+				context.send(text, { reply_markup: keyboard }),
+			]);
 			return;
 		}
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,4 @@
-import type { BotLike, ContextType } from "gramio";
+import type { BotLike, ContextType, MaybePromise } from "gramio";
 import { ResponseView } from "./response.ts";
 import { isInlineMarkup, type WithResponseContext } from "./utils.ts";
 
@@ -9,7 +9,7 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 		private readonly render: (
 			this: WithResponseContext<Globals>,
 			...args: Args
-		) => ResponseView,
+		) => MaybePromise<ResponseView>,
 	) {}
 
 	async renderWithContext(
@@ -19,7 +19,7 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 		strategyRaw?: "send" | "edit",
 	) {
 		const contextData = this.createContext(globals);
-		const result = this.render.apply(contextData, args);
+		const result = await this.render.apply(contextData, args);
 		const response = result[responseKey];
 
 		const canEdit = context.is("callback_query") && !!context.message;

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,6 @@
-import type { BotLike, Context } from "gramio";
+import type { BotLike, Context, TelegramInputMedia } from "gramio";
 import { ResponseView } from "./response.ts";
-import type { WithResponseContext } from "./utils.ts";
+import { isInlineMarkup, type WithResponseContext } from "./utils.ts";
 
 const responseKey = "response";
 
@@ -18,30 +18,62 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 		args: Args,
 	) {
 		const contextData = this.createContext(globals);
-
 		const result = this.render.apply(contextData, args);
-
 		const response = result[responseKey];
+		const { text, keyboard, media: desiredMedia } = response;
 
-		if (context.is("message")) {
-			if (response.text) {
-				await context.send(response.text, {
-					reply_markup: response.keyboard,
+		if (
+			context.is("message") ||
+			(context.is("callback_query") && !context.message)
+		) {
+			if (desiredMedia) {
+				// @ts-expect-error
+				await context.sendMedia({
+					type: desiredMedia.type,
+					[desiredMedia.type]: desiredMedia.media,
+					caption: text,
+					reply_markup: keyboard,
 				});
+			} else if (text) {
+				await context.send(text, { reply_markup: keyboard });
 			}
-		} else if (context.is("callback_query")) {
-			if (response.text) {
-				const builtKeyboard =
-					response.keyboard && "toJSON" in response.keyboard
-						? response.keyboard.toJSON()
-						: undefined;
+			if (context.is("callback_query")) {
+				await context.answer();
+			}
+			return;
+		}
 
-				await context.editText(response.text, {
-					reply_markup:
-						builtKeyboard && "inline_keyboard" in builtKeyboard
-							? builtKeyboard
-							: undefined,
-				});
+		if (context.is("callback_query") && context.message) {
+			const isCurrentMedia = context.message.hasAttachment();
+			const isDesiredMedia = !!desiredMedia;
+
+			if (isCurrentMedia && !isDesiredMedia && text) {
+				await context.message.delete();
+				await context.send(text, { reply_markup: keyboard });
+				return;
+			}
+
+			if (isDesiredMedia) {
+				const media: TelegramInputMedia = {
+					type: desiredMedia.type,
+					media: desiredMedia.media,
+					caption: text,
+				};
+				const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
+				await context.editMedia(media, { reply_markup: inlineMarkup });
+				return;
+			}
+
+			if (!isCurrentMedia && text) {
+				const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
+				await context.editText(text, { reply_markup: inlineMarkup });
+				return;
+			}
+
+			if (keyboard && !text && !desiredMedia) {
+				const inlineMarkup = isInlineMarkup(keyboard) ? keyboard : undefined;
+				await context.editReplyMarkup(inlineMarkup);
+				return;
 			}
 		}
 	}

--- a/src/render.ts
+++ b/src/render.ts
@@ -61,11 +61,11 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 			}
 			await context.sendMediaGroup(media);
 		} else if (media) {
-			const signleMedia = Array.isArray(media) ? media[0] : media;
+			const singleMedia = Array.isArray(media) ? media[0] : media;
 			// @ts-expect-error
 			await context.sendMedia({
-				type: signleMedia.type,
-				[signleMedia.type]: signleMedia.media,
+				type: singleMedia.type,
+				[singleMedia.type]: singleMedia.media,
 				caption: text,
 				reply_markup: keyboard,
 			});

--- a/src/render.ts
+++ b/src/render.ts
@@ -85,6 +85,10 @@ export class ViewRender<Globals extends object, Args extends any[]> {
 		}
 
 		if (Array.isArray(media)) {
+			const lastMedia = media.at(-1);
+			if (lastMedia && text) {
+				lastMedia.caption = text;
+			}
 			await context.message.delete();
 			await context.sendMediaGroup(media);
 			return;

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,4 +1,4 @@
-import type { APIMethodParams } from "gramio";
+import type { APIMethodParams, TelegramInputMedia } from "gramio";
 
 type Text = string | { toString(): string };
 
@@ -8,6 +8,7 @@ export class ResponseView {
 		keyboard: undefined as
 			| APIMethodParams<"sendMessage">["reply_markup"]
 			| undefined,
+		media: undefined as TelegramInputMedia | undefined,
 	};
 
 	text(text: Text) {
@@ -18,6 +19,12 @@ export class ResponseView {
 
 	keyboard(keyboard: APIMethodParams<"sendMessage">["reply_markup"]) {
 		this.response.keyboard = keyboard;
+
+		return this;
+	}
+
+	media(media: TelegramInputMedia) {
+		this.response.media = media;
 
 		return this;
 	}

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,14 +1,15 @@
-import type { APIMethodParams, TelegramInputMedia } from "gramio";
+import type { TelegramInputMedia, TelegramParams } from "gramio";
 
 type Text = string | { toString(): string };
+type Keyboard = TelegramParams.SendMessageParams["reply_markup"];
+type Media = TelegramInputMedia;
+type MediaGroup = TelegramParams.SendMediaGroupParams["media"];
 
 export class ResponseView {
 	private readonly response = {
 		text: undefined as Text | undefined,
-		keyboard: undefined as
-			| APIMethodParams<"sendMessage">["reply_markup"]
-			| undefined,
-		media: undefined as TelegramInputMedia | undefined,
+		keyboard: undefined as Keyboard | undefined,
+		media: undefined as Media | MediaGroup | undefined,
 	};
 
 	text(text: Text) {
@@ -17,13 +18,13 @@ export class ResponseView {
 		return this;
 	}
 
-	keyboard(keyboard: APIMethodParams<"sendMessage">["reply_markup"]) {
+	keyboard(keyboard: Keyboard) {
 		this.response.keyboard = keyboard;
 
 		return this;
 	}
 
-	media(media: TelegramInputMedia) {
+	media(media: Media | MediaGroup) {
 		this.response.media = media;
 
 		return this;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,12 +50,12 @@ export interface InitViewsBuilderReturn<Globals extends object> {
 }
 
 export function isInlineMarkup(
-	markup: any,
+	markup: unknown,
 ): markup is TelegramInlineKeyboardMarkup {
 	if (!markup || typeof markup !== "object") {
 		return false;
 	}
-	if (typeof markup.toJSON === "function") {
+	if ("toJSON" in markup && typeof markup.toJSON === "function") {
 		const json = markup.toJSON();
 		return "inline_keyboard" in json;
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { BotLike, Context } from "gramio";
+import type { BotLike, Context, TelegramInlineKeyboardMarkup } from "gramio";
 import type { ViewRender } from "./render.ts";
 import type { ResponseView } from "./response.ts";
 import type { ViewBuilder } from "./view.ts";
@@ -28,4 +28,17 @@ export interface InitViewsBuilderReturn<Globals extends object> {
 		view: View,
 		...args: ExtractViewArgs<View>
 	) => void;
+}
+
+export function isInlineMarkup(
+	markup: any,
+): markup is TelegramInlineKeyboardMarkup {
+	if (!markup || typeof markup !== "object") {
+		return false;
+	}
+	if (typeof markup.toJSON === "function") {
+		const json = markup.toJSON();
+		return "inline_keyboard" in json;
+	}
+	return "inline_keyboard" in markup;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,9 @@
-import type { BotLike, Context, TelegramInlineKeyboardMarkup } from "gramio";
+import type {
+	BotLike,
+	Context,
+	ContextType,
+	TelegramInlineKeyboardMarkup,
+} from "gramio";
 import type { ViewRender } from "./render.ts";
 import type { ResponseView } from "./response.ts";
 import type { ViewBuilder } from "./view.ts";

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,3 +1,4 @@
+import type { MaybePromise } from "gramio";
 import { ViewRender } from "./render.ts";
 import type { ResponseView } from "./response.ts";
 import type { WithResponseContext } from "./utils.ts";
@@ -7,7 +8,7 @@ export class ViewBuilder<Globals extends object> {
 		callback: (
 			this: WithResponseContext<Globals>,
 			...args: Args
-		) => ResponseView,
+		) => MaybePromise<ResponseView>,
 	) {
 		return new ViewRender(callback);
 	}


### PR DESCRIPTION
This PR introduces support for media attachments to the plugin.

Correctly manages all state transitions:
- Text -> Text
- Text -> Media
- Media -> Media
- Media -> Text: Solved by deleting the old media message and sending a new text message, as the Telegram API doesn't support this transition directly.